### PR TITLE
Quick markdown fix on Gatsby's resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Also check out [Awesome AWS AppSync](https://github.com/dabit3/awesome-aws-appsy
 
 #### Gatsby
 
-- [https://medium.com/@kurtiskemple/building-jamstack-applications-with-gatsby-and-aws-amplify-framework-d7e2b9e7117e](Building JAMstack Applications with Gatsby and AWS Amplify Framework)
+- [Building JAMstack Applications with Gatsby and AWS Amplify Framework](https://medium.com/@kurtiskemple/building-jamstack-applications-with-gatsby-and-aws-amplify-framework-d7e2b9e7117e)
 
 #### Ember
 


### PR DESCRIPTION
The order of the link was swapped between the label and URL, but now it's fixed. Super minor change that can maybe help the dissemination of Kurtis' article (which is great, btw) 😉

Thanks for the work, y'all!